### PR TITLE
adjusted the instructions in step2.md to include switching to Tab1 be…

### DIFF
--- a/streetlight-tut/step2.md
+++ b/streetlight-tut/step2.md
@@ -6,7 +6,7 @@ To generate your code you'll use the [AsyncAPI Generator](https://github.com/asy
 
 1. Trigger generation of the Node.js code: `ag asyncapi.yaml @asyncapi/nodejs-template -o output -p server=mosquitto`{{exec}}
 
-1. And voilà! In the editor you can see a new folder is created with generated Node.js application. Enter the folder in the terminal: `cd output`{{exec}}
+1. And voilà! In the editor you can see a new folder is created with generated Node.js application. Goto your `Tab1` terminal and enter the `output` folder from the there: `cd output`{{exec}}
 
 # Start your generated service
 

--- a/streetlight-tut/step2.md
+++ b/streetlight-tut/step2.md
@@ -6,7 +6,7 @@ To generate your code you'll use the [AsyncAPI Generator](https://github.com/asy
 
 1. Trigger generation of the Node.js code: `ag asyncapi.yaml @asyncapi/nodejs-template -o output -p server=mosquitto`{{exec}}
 
-1. And voilà! In the editor you can see a new folder is created with generated Node.js application. Goto your `Tab1` terminal and enter the `output` folder from the there: `cd output`{{exec}}
+1. And voilà! In the editor you can see a new folder is created with generated Node.js application. Goto your `Tab1` terminal and enter the `output` folder from there: `cd output`{{exec}}
 
 # Start your generated service
 

--- a/streetlight-tut/step2.md
+++ b/streetlight-tut/step2.md
@@ -6,7 +6,7 @@ To generate your code you'll use the [AsyncAPI Generator](https://github.com/asy
 
 1. Trigger generation of the Node.js code: `ag asyncapi.yaml @asyncapi/nodejs-template -o output -p server=mosquitto`{{exec}}
 
-1. And voilà! In the editor you can see a new folder is created with generated Node.js application. Goto your `Tab1` terminal and enter the `output` folder from there: `cd output`{{exec}}
+1. And voilà! In the editor, you can see a new folder is created with generated Node.js application. Go to your `Tab1` terminal and enter the `output` folder from there: `cd output`{{exec}}
 
 # Start your generated service
 


### PR DESCRIPTION
## Issue Summary
This Pull Request improved on the instructions in [step2.md](https://github.com/activus-d/asyncapi-killercoda-interactive-tutorials/blob/main/streetlight-tut/step2.md) by informing the user to switch to a different terminal (Tab 1) and enter the output directory (with cd output) from there.
